### PR TITLE
Feat: Auto-updating quickstart version

### DIFF
--- a/src/content/doc/0-getting-started--2-quick-start/en.md
+++ b/src/content/doc/0-getting-started--2-quick-start/en.md
@@ -28,7 +28,7 @@ If you prefer working locally **without a complex setup**, you can import Odyc.j
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<script src="https://www.unpkg.com/odyc@0.0.18/dist/index.global.js"></script>
+		<script src="https://www.unpkg.com/odyc@latest/dist/index.global.js"></script>
 	</head>
 	<body>
 		<script>

--- a/src/content/doc/0-getting-started--2-quick-start/fr.md
+++ b/src/content/doc/0-getting-started--2-quick-start/fr.md
@@ -28,7 +28,7 @@ Si vous préférez travailler localement **sans configuration complexe**, vous p
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<script src="https://www.unpkg.com/odyc@0.0.18/dist/index.global.js"></script>
+		<script src="https://www.unpkg.com/odyc@latest/dist/index.global.js"></script>
 	</head>
 	<body>
 		<script>


### PR DESCRIPTION
Currently, CDN in quickstart is around 80 patch versions behind. This will likely remain problem forever, even if I increased it now.

Instead, I used `latest` alias, which redirects to the most recent version. While this is not be best for production use (unwanted updated, and uncached requests), for purpose of quickstart, it sounds reasonable - and removes need to maintain a version number.

> URLs that do not specify a fully resolved package version number redirect to one that does. This is the latest version when none is specified, or the maximum satisfying version when a semver range is given. [Source](https://unpkg.com/)